### PR TITLE
Update Ring.cs

### DIFF
--- a/Assets/DaydreamElements/Elements/SwipeMenu/Demo/Scripts/Ring.cs
+++ b/Assets/DaydreamElements/Elements/SwipeMenu/Demo/Scripts/Ring.cs
@@ -31,7 +31,7 @@ namespace DaydreamElements.SwipeMenu {
     }
 
     void Update() {
-      gameObject.GetComponent<SpriteRenderer>().color = color;
+      spriteRenderer.color = color;
       color = color * 0.9f + Color.white * 0.1f;
     }
 


### PR DESCRIPTION
cached referenced to SpriteRenderer wasn't being used, instead GetComponent was being called on Update.